### PR TITLE
Fix icub-models dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
    pyqtconsole
    matplotlib
    h5py
-   icub-models
+   icub-models >= 1.23.2
 include_package_data = True
 
 [options.entry_points]


### PR DESCRIPTION
`robot-log-visualizer` depends from `icub-models` python bindings release in `1.23.2` release of icub-models, this PR enforce on the version required.

(see https://github.com/robotology/icub-models/pull/144)