### PR TITLE
fix usage with different name from robot_logger_device

### DIFF
--- a/robot_log_visualizer/robot_visualizer/meshcat_provider.py
+++ b/robot_log_visualizer/robot_visualizer/meshcat_provider.py
@@ -55,7 +55,7 @@ class MeshcatProvider(QThread):
             if self.state == PeriodicThreadState.running:
 
                 # These are the robot measured joint positions in radians
-                joints = self._signal_provider.data["robot_logger_device"][
+                joints = self._signal_provider.data[self._signal_provider.root_name][
                     "joints_state"
                 ]["positions"]["data"]
 


### PR DESCRIPTION
It fixes #37

@Nicogene and I added the possibility to load a mat file with a variable name different from `robot_logger_device`.

![robot_logger_device_01](https://user-images.githubusercontent.com/19833605/163572173-0536cfbd-3448-47b9-af39-d1a301096758.jpg)

