### PR TITLE
Look for the urdf model inside a set of environment variables

### DIFF
--- a/robot_log_visualizer/robot_visualizer/meshcat_provider.py
+++ b/robot_log_visualizer/robot_visualizer/meshcat_provider.py
@@ -6,6 +6,10 @@ from PyQt5.QtCore import QThread, QMutex, QMutexLocker
 
 import icub_models
 
+import os
+import re
+from pathlib import Path
+
 import numpy as np
 import time
 
@@ -28,6 +32,7 @@ class MeshcatProvider(QThread):
 
         self.custom_model_path = ""
         self.custom_package_dir = ""
+        self.env_list = ["GAZEBO_MODEL_PATH", "ROS_PACKAGE_PATH", "AMENT_PREFIX_PATH"]
 
     @property
     def state(self):
@@ -41,6 +46,17 @@ class MeshcatProvider(QThread):
         self._state = new_state
 
     def load_model(self, considered_joints, model_name):
+        def get_model_path_from_envs(env_list):
+            return [
+                Path(f) if (env != "AMENT_PREFIX_PATH") else Path(f) / "share"
+                for env in env_list
+                for f in os.getenv(env).split(os.pathsep)
+            ]
+
+        def check_if_model_exist(folder_path, model):
+            path = folder_path / Path(model)
+            return path.is_dir()
+
         model_loader = idyn.ModelLoader()
 
         if self.custom_model_path:
@@ -51,10 +67,25 @@ class MeshcatProvider(QThread):
                 [self.custom_package_dir],
             )
         else:
-            if not model_name in icub_models.get_robot_names():
-                model_name = "iCubGenova09"
 
-            self.custom_model_path = str(icub_models.get_model_file(model_name))
+            model_found_in_env_folders = False
+            for folder in get_model_path_from_envs(self.env_list):
+                if check_if_model_exist(folder, model_name):
+                    folder_model_path = folder / Path(model_name)
+                    model_filenames = [
+                        folder_model_path / Path(f)
+                        for f in os.listdir(folder_model_path.absolute())
+                        if re.search("[a-zA-Z0-9_]*\.urdf", f)
+                    ]
+
+                    if model_filenames:
+                        model_found_in_env_folders = True
+                        self.custom_model_path = str(model_filenames[0])
+                        break
+
+            if not model_found_in_env_folders:
+                self.custom_model_path = str(icub_models.get_model_file(model_name))
+
             model_loader.loadReducedModelFromFile(
                 self.custom_model_path, considered_joints
             )
@@ -75,7 +106,6 @@ class MeshcatProvider(QThread):
             start = time.time()
 
             if self.state == PeriodicThreadState.running:
-
                 # These are the robot measured joint positions in radians
                 joints = self._signal_provider.data[self._signal_provider.root_name][
                     "joints_state"


### PR DESCRIPTION
The following environment variables are supported: GAZEBO_MODEL_PATH, ROS_PACKAGE_PATH, AMENT_PREFIX_PATH

This closes #35 

This means that, given a dataset collected from the ergoCub robot, the model will be automatically loaded if installed in the system

@traversaro do you think we should look into other folders? Moreover, do you think we should port this feature in iDynTree? For instance with a function named `loadModelFromEnv()`


cc @xenvre
