### PR TITLE
🐛 Fix the robot visualization when the dataset contains signals retrieved at different frequencies

### DIFF
--- a/robot_log_visualizer/file_reader/signal_provider.py
+++ b/robot_log_visualizer/file_reader/signal_provider.py
@@ -193,6 +193,9 @@ class SignalProvider(QThread):
     def register_update_index(self, slot):
         self.update_index_signal.connect(slot)
 
+    def set_dataset_percentage(self, percentage):
+        self.update_index(int(percentage * len(self)))
+
     def update_index(self, index):
         locker = QMutexLocker(self.index_lock)
         self._index = max(min(index, len(self.timestamps) - 1), 0)
@@ -203,6 +206,19 @@ class SignalProvider(QThread):
         locker = QMutexLocker(self.index_lock)
         value = self._current_time
         return value
+
+    def get_joints_position(self):
+        return self.data[self.root_name]["joints_state"]["positions"]["data"]
+
+    def get_joints_position_at_index(self, index):
+        joints_position_timestamps = self.data[self.root_name]["joints_state"][
+            "positions"
+        ]["timestamps"]
+        # given the index find the closest timestamp
+        closest_index = np.argmin(
+            np.abs(joints_position_timestamps - self.timestamps[index])
+        )
+        return self.get_joints_position()[closest_index, :]
 
     def run(self):
         while True:

--- a/robot_log_visualizer/robot_visualizer/meshcat_provider.py
+++ b/robot_log_visualizer/robot_visualizer/meshcat_provider.py
@@ -149,16 +149,12 @@ class MeshcatProvider(QThread):
 
             if self.state == PeriodicThreadState.running and self._is_model_loaded:
                 # These are the robot measured joint positions in radians
-                joints = self._signal_provider.data[self._signal_provider.root_name][
-                    "joints_state"
-                ]["positions"]["data"]
-
                 self.meshcat_visualizer.set_multibody_system_state(
                     base_position,
                     base_rotation,
-                    joint_value=joints[
-                        self._signal_provider.index, self.model_joints_index
-                    ],
+                    joint_value=self._signal_provider.get_joints_position_at_index(
+                        self._signal_provider.index
+                    )[self.model_joints_index],
                     model_name="robot",
                 )
 

--- a/robot_log_visualizer/ui/gui.py
+++ b/robot_log_visualizer/ui/gui.py
@@ -246,7 +246,10 @@ class RobotViewerMainWindow(QtWidgets.QMainWindow):
             if event.key() == Qt.Key_B:
                 self.slider_pressed = True
                 new_index = int(self.ui.timeSlider.value()) - 1
-                self.signal_provider.update_index(new_index)
+                dataset_percentage = float(new_index) / float(
+                    self.ui.timeSlider.maximum()
+                )
+                self.signal_provider.set_dataset_percentage(dataset_percentage)
                 self.ui.timeLabel.setText(f"{self.signal_provider.current_time:.2f}")
                 self.text_logger.highlight_cell(
                     self.find_text_log_index(self.get_text_log_item_path())
@@ -255,11 +258,8 @@ class RobotViewerMainWindow(QtWidgets.QMainWindow):
                 # for every video item we set the instant
                 for video_item in self.video_items:
                     if video_item.media_loaded:
-                        video_percentage = float(new_index) / float(
-                            self.ui.timeSlider.maximum()
-                        )
                         video_item.media_player.setPosition(
-                            int(video_percentage * video_item.media_player.duration())
+                            int(dataset_percentage * video_item.media_player.duration())
                         )
 
                 # update the time slider
@@ -268,7 +268,10 @@ class RobotViewerMainWindow(QtWidgets.QMainWindow):
             elif event.key() == Qt.Key_F:
                 self.slider_pressed = True
                 new_index = int(self.ui.timeSlider.value()) + 1
-                self.signal_provider.update_index(new_index)
+                dataset_percentage = float(new_index) / float(
+                    self.ui.timeSlider.maximum()
+                )
+                self.signal_provider.set_dataset_percentage(dataset_percentage)
                 self.ui.timeLabel.setText(f"{self.signal_provider.current_time:.2f}")
                 self.text_logger.highlight_cell(
                     self.find_text_log_index(self.get_text_log_item_path())
@@ -277,11 +280,8 @@ class RobotViewerMainWindow(QtWidgets.QMainWindow):
                 # for every video item we set the instant
                 for video_item in self.video_items:
                     if video_item.media_loaded:
-                        video_percentage = float(new_index) / float(
-                            self.ui.timeSlider.maximum()
-                        )
                         video_item.media_player.setPosition(
-                            int(video_percentage * video_item.media_player.duration())
+                            int(dataset_percentage * video_item.media_player.duration())
                         )
 
                 self.ui.timeSlider.setValue(new_index)
@@ -303,15 +303,15 @@ class RobotViewerMainWindow(QtWidgets.QMainWindow):
 
     def timeSlider_on_sliderMoved(self):
         index = int(self.ui.timeSlider.value())
+        dataset_percentage = float(index) / float(self.ui.timeSlider.maximum())
 
         for video_item in self.video_items:
             if video_item.media_loaded:
-                video_percentage = float(index) / float(self.ui.timeSlider.maximum())
                 video_item.media_player.setPosition(
-                    int(video_percentage * video_item.media_player.duration())
+                    int(dataset_percentage * video_item.media_player.duration())
                 )
 
-        self.signal_provider.update_index(index)
+        self.signal_provider.set_dataset_percentage(dataset_percentage)
         self.ui.timeLabel.setText(f"{self.signal_provider.current_time:.2f}")
         self.text_logger.highlight_cell(
             self.find_text_log_index(self.get_text_log_item_path())
@@ -319,15 +319,15 @@ class RobotViewerMainWindow(QtWidgets.QMainWindow):
 
     def timeSlider_on_release(self):
         index = int(self.ui.timeSlider.value())
+        dataset_percentage = float(index) / float(self.ui.timeSlider.maximum())
 
         for video_item in self.video_items:
             if video_item.media_loaded:
-                video_percentage = float(index) / float(self.ui.timeSlider.maximum())
                 video_item.media_player.setPosition(
-                    int(video_percentage * video_item.media_player.duration())
+                    int(dataset_percentage * video_item.media_player.duration())
                 )
 
-        self.signal_provider.update_index(index)
+        self.signal_provider.set_dataset_percentage(dataset_percentage)
         self.ui.timeLabel.setText(f"{self.signal_provider.current_time:.2f}")
         self.text_logger.highlight_cell(
             self.find_text_log_index(self.get_text_log_item_path())
@@ -475,22 +475,24 @@ class RobotViewerMainWindow(QtWidgets.QMainWindow):
 
     @pyqtSlot()
     def update_index(self):
-        if not self.slider_pressed:
-            self.ui.timeSlider.setValue(self.signal_provider.index)
-            self.ui.timeLabel.setText(f"{self.signal_provider.current_time:.2f}")
-            self.text_logger.highlight_cell(
-                self.find_text_log_index(self.get_text_log_item_path())
-            )
+        if self.slider_pressed:
+            return
 
-            # TODO: this is a hack to update the video player and it should be done only for the activated videos
-            for video_item in self.video_items:
-                if video_item.media_loaded:
-                    video_percentage = float(self.ui.timeSlider.value()) / float(
-                        self.ui.timeSlider.maximum()
-                    )
-                    video_item.media_player.setPosition(
-                        int(video_percentage * video_item.media_player.duration())
-                    )
+        self.ui.timeSlider.setValue(self.signal_provider.index)
+        self.ui.timeLabel.setText(f"{self.signal_provider.current_time:.2f}")
+        self.text_logger.highlight_cell(
+            self.find_text_log_index(self.get_text_log_item_path())
+        )
+
+        # TODO: this is a hack to update the video player and it should be done only for the activated videos
+        for video_item in self.video_items:
+            if video_item.media_loaded:
+                video_percentage = float(self.ui.timeSlider.value()) / float(
+                    self.ui.timeSlider.maximum()
+                )
+                video_item.media_player.setPosition(
+                    int(video_percentage * video_item.media_player.duration())
+                )
 
     def closeEvent(self, event):
         # close the window


### PR DESCRIPTION
This PR addressed #71. The problem identified in #71 was caused by a discrepancy in the data collection frequencies—image signals were captured at 30fps, while joint data was recorded at 100Hz. In this specific dataset, we encountered an unfortunate situation where the initial timestamp of the camera data was lower than the first timestamp of the joints. Consequently, the visualizer erroneously used the camera timestamps as the base timestamp for the entire dataset.

To resolve this issue, the PR introduces a fix that computes the correct time joint index based on the common timestamps used by the visualizer. This ensures proper synchronization and resolves the problems observed in #71.