### PR TITLE
✨ Add the possibility to set the base pose in the visualizer and add the 3D point visualization

### DIFF
--- a/robot_log_visualizer/file_reader/signal_provider.py
+++ b/robot_log_visualizer/file_reader/signal_provider.py
@@ -7,7 +7,8 @@ import math
 import h5py
 import numpy as np
 from PyQt5.QtCore import pyqtSignal, QThread, QMutex, QMutexLocker
-from robot_log_visualizer.utils.utils import PeriodicThreadState
+from robot_log_visualizer.utils.utils import PeriodicThreadState, RobotStatePath
+import idyntree.swig as idyn
 
 
 class TextLoggingMsg:
@@ -40,6 +41,12 @@ class SignalProvider(QThread):
 
         self._index = 0
         self.index_lock = QMutex()
+
+        self._robot_state_path = RobotStatePath()
+        self.robot_state_path_lock = QMutex()
+
+        self._3d_points_path = {}
+        self._3d_points_path_lock = QMutex()
 
         self.period = period
 
@@ -190,6 +197,17 @@ class SignalProvider(QThread):
         locker = QMutexLocker(self.index_lock)
         self._index = index
 
+    @property
+    def robot_state_path(self):
+        locker = QMutexLocker(self.robot_state_path_lock)
+        value = self._robot_state_path
+        return value
+
+    @robot_state_path.setter
+    def robot_state_path(self, robot_state_path):
+        locker = QMutexLocker(self.robot_state_path_lock)
+        self._robot_state_path = robot_state_path
+
     def register_update_index(self, slot):
         self.update_index_signal.connect(slot)
 
@@ -207,18 +225,98 @@ class SignalProvider(QThread):
         value = self._current_time
         return value
 
-    def get_joints_position(self):
-        return self.data[self.root_name]["joints_state"]["positions"]["data"]
+    def get_item_from_path(self, path, default_path=None):
+        data = self.data[self.root_name]
 
-    def get_joints_position_at_index(self, index):
-        joints_position_timestamps = self.data[self.root_name]["joints_state"][
-            "positions"
-        ]["timestamps"]
-        # given the index find the closest timestamp
-        closest_index = np.argmin(
-            np.abs(joints_position_timestamps - self.timestamps[index])
+        if not path:
+            if default_path is None:
+                return None, None
+            else:
+                for key in default_path:
+                    data = data[key]
+                return data["data"], data["timestamps"]
+
+        for key in path:
+            data = data[key]
+
+        return data["data"], data["timestamps"]
+
+    def get_item_from_path_at_index(self, path, index, default_path=None):
+        data, timestamps = self.get_item_from_path(path, default_path)
+        if data is None:
+            return None
+        closest_index = np.argmin(np.abs(timestamps - self.timestamps[index]))
+        return data[closest_index, :]
+
+    def get_robot_state_at_index(self, index):
+        robot_state = {}
+
+        self.robot_state_path_lock.lock()
+        robot_state["joints_position"] = self.get_item_from_path_at_index(
+            self._robot_state_path.joints_state_path,
+            index,
+            default_path=["joints_state", "positions"],
         )
-        return self.get_joints_position()[closest_index, :]
+
+        robot_state["base_position"] = self.get_item_from_path_at_index(
+            self._robot_state_path.base_position_path, index
+        )
+
+        robot_state["base_orientation"] = self.get_item_from_path_at_index(
+            self._robot_state_path.base_orientation_path, index
+        )
+        self.robot_state_path_lock.unlock()
+
+        if robot_state["base_position"] is None:
+            robot_state["base_position"] = np.zeros(3)
+
+        if robot_state["base_orientation"] is None:
+            robot_state["base_orientation"] = np.zeros(3)
+
+        # check the size of the base_orientation if 3 we assume is store ad rpy otherwise as a quaternion we need to convert it in a rotation matrix
+        if robot_state["base_orientation"].shape[0] == 3:
+            robot_state["base_orientation"] = idyn.Rotation.RPY(
+                robot_state["base_orientation"][0],
+                robot_state["base_orientation"][1],
+                robot_state["base_orientation"][2],
+            ).toNumPy()
+        if robot_state["base_orientation"].shape[0] == 4:
+            # convert the x y z w quaternion into w x y z
+            tmp_quat = robot_state["base_orientation"]
+            tmp_quat = np.array([tmp_quat[3], tmp_quat[0], tmp_quat[1], tmp_quat[2]])
+
+            robot_state["base_orientation"] = idyn.Rotation.RotationFromQuaternion(
+                tmp_quat
+            ).toNumPy()
+
+        return robot_state
+
+    def get_3d_point_at_index(self, index):
+        points = {}
+
+        self._3d_points_path_lock.lock()
+
+        for key, value in self._3d_points_path.items():
+            # force the size of the points to be 3 if less than 3 we assume that the point is a 2d point and we add a 0 as z coordinate
+            points[key] = self.get_item_from_path_at_index(value, index)
+            if points[key].shape[0] < 3:
+                points[key] = np.concatenate(
+                    (points[key], np.zeros(3 - points[key].shape[0]))
+                )
+
+        self._3d_points_path_lock.unlock()
+
+        return points
+
+    def register_3d_point(self, key, points_path):
+        self._3d_points_path_lock.lock()
+        self._3d_points_path[key] = points_path
+        self._3d_points_path_lock.unlock()
+
+    def unregister_3d_point(self, key):
+        self._3d_points_path_lock.lock()
+        del self._3d_points_path[key]
+        self._3d_points_path_lock.unlock()
 
     def run(self):
         while True:

--- a/robot_log_visualizer/ui/gui.py
+++ b/robot_log_visualizer/ui/gui.py
@@ -747,7 +747,7 @@ class RobotViewerMainWindow(QtWidgets.QMainWindow):
             if item_path == self.robot_state_path.base_orientation_path:
                 menu.addAction(dont_use_as_base_orientation_str)
             else:
-                menu.addAction(use_as_base_orientation_str)
+                menu.addAction(use_as_base_orientation_str + " (Roll-Pitch-Yaw)")
 
             menu.addSeparator()
 
@@ -760,7 +760,7 @@ class RobotViewerMainWindow(QtWidgets.QMainWindow):
             if item_path == self.robot_state_path.base_orientation_path:
                 menu.addAction(dont_use_as_base_orientation_str)
             else:
-                menu.addAction(use_as_base_orientation_str)
+                menu.addAction(use_as_base_orientation_str + " (xyzw Quaternion)")
 
         # show the menu
         action = menu.exec_(self.ui.variableTreeWidget.mapToGlobal(item_position))
@@ -786,7 +786,7 @@ class RobotViewerMainWindow(QtWidgets.QMainWindow):
             item.setForeground(0, QtGui.QBrush(QtGui.QColor(0, 0, 0)))
 
         if (
-            action.text() == use_as_base_orientation_str
+            use_as_base_orientation_str in action.text()
             or action.text() == use_as_base_position_str
         ):
             item.setBackground(0, QtGui.QBrush(selected_base_color))
@@ -800,7 +800,7 @@ class RobotViewerMainWindow(QtWidgets.QMainWindow):
                 ).setBackground(0, QtGui.QBrush(deselected_base_color))
             self.robot_state_path.base_position_path = item_path
 
-        if action.text() == use_as_base_orientation_str:
+        if use_as_base_orientation_str in action.text():
             # if base orientation is already set we remove the color
             if self.robot_state_path.base_orientation_path:
                 self.get_item_from_path(

--- a/robot_log_visualizer/ui/gui.py
+++ b/robot_log_visualizer/ui/gui.py
@@ -22,7 +22,12 @@ from robot_log_visualizer.ui.plot_item import PlotItem
 from robot_log_visualizer.ui.video_item import VideoItem
 from robot_log_visualizer.ui.text_logging import TextLoggingItem
 
-from robot_log_visualizer.utils.utils import PeriodicThreadState
+from robot_log_visualizer.utils.utils import (
+    PeriodicThreadState,
+    RobotStatePath,
+    ColorPalette,
+    Color,
+)
 
 import sys
 import os
@@ -159,6 +164,8 @@ class RobotViewerMainWindow(QtWidgets.QMainWindow):
 
         self.plot_items = []
         self.video_items = []
+        self.visualized_3d_points = set()
+        self.visualized_3d_points_colors_palette = ColorPalette()
 
         self.toolButton_on_click()
 
@@ -181,7 +188,7 @@ class RobotViewerMainWindow(QtWidgets.QMainWindow):
         self.ui.actionSet_Robot_Model.triggered.connect(self.open_set_robot_model)
 
         self.ui.meshcatView.setUrl(
-            QUrl(meshcat_provider.meshcat_visualizer.viewer.url())
+            QUrl(meshcat_provider._meshcat_visualizer.viewer.url())
         )
 
         self.ui.pauseButton.clicked.connect(self.pauseButton_on_click)
@@ -202,6 +209,14 @@ class RobotViewerMainWindow(QtWidgets.QMainWindow):
             self.plotTabBar_on_doubleClick
         )
         self.ui.tabPlotWidget.currentChanged.connect(self.plotTabBar_currentChanged)
+
+        # add a custom context menu to the variable tree widget
+        self.ui.variableTreeWidget.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.ui.variableTreeWidget.customContextMenuRequested.connect(
+            self.variableTreeWidget_on_right_click
+        )
+
+        self.robot_state_path = RobotStatePath()
 
         self.pyconsole = PythonConsole(
             parent=self.ui.pythonWidget,
@@ -389,6 +404,11 @@ class RobotViewerMainWindow(QtWidgets.QMainWindow):
 
             paths.append(path)
             legends.append(legend)
+
+        # if there is no selection we do nothing
+        if not paths:
+            return
+
         self.plot_items[self.ui.tabPlotWidget.currentIndex()].canvas.update_plots(
             paths, legends
         )
@@ -668,6 +688,158 @@ class RobotViewerMainWindow(QtWidgets.QMainWindow):
             event.accept()
         else:
             event.ignore()
+
+    def variableTreeWidget_on_right_click(self, item_position):
+        # check if the variable tree widget is empty
+        if self.ui.variableTreeWidget.topLevelItemCount() == 0:
+            menu = QtWidgets.QMenu()
+            menu.addAction("Open a mat file")
+            action = menu.exec_(self.ui.variableTreeWidget.mapToGlobal(item_position))
+            if action is None:
+                return
+            if action.text() == "Open a mat file":
+                self.open_mat_file()
+
+            return
+
+        # find the item from the position
+        item = self.ui.variableTreeWidget.itemAt(item_position)
+        if item is None:
+            return
+
+        if item.childCount() == 0:
+            return
+
+        # the child has to be a leaf
+        if item.child(0).childCount() != 0:
+            return
+
+        # check the number of children
+        item_size = item.childCount()
+        item_path = self.get_item_path(item)
+        item_key = "/".join(item_path)
+
+        menu = QtWidgets.QMenu()
+
+        add_3d_point_str = "Show as a 3D point"
+        remove_3d_point_str = "Remove the 3D point"
+        use_as_base_position_str = "Use as base position"
+        use_as_base_orientation_str = "Use as base orientation"
+        dont_use_as_base_position_str = "Don't use as base position"
+        dont_use_as_base_orientation_str = "Don't use as base orientation"
+        selected_base_color = QtGui.QColor(255, 0, 0, 127)
+        deselected_base_color = QtGui.QColor(0, 0, 0, 0)
+
+        # in this case we can use the item as 3d point where the z coordinate is set to 0
+        if item_size == 2:
+            if item_key in self.visualized_3d_points:
+                menu.addAction(remove_3d_point_str)
+            else:
+                menu.addAction(add_3d_point_str)
+
+        # in this case we can use the item as base position, base orientation or 3d point
+        if item_size == 3:
+            if item_path == self.robot_state_path.base_position_path:
+                menu.addAction(dont_use_as_base_position_str)
+            else:
+                menu.addAction(use_as_base_position_str)
+
+            if item_path == self.robot_state_path.base_orientation_path:
+                menu.addAction(dont_use_as_base_orientation_str)
+            else:
+                menu.addAction(use_as_base_orientation_str)
+
+            menu.addSeparator()
+
+            if item_key in self.visualized_3d_points:
+                menu.addAction(remove_3d_point_str)
+            else:
+                menu.addAction(add_3d_point_str)
+
+        if item_size == 4:
+            if item_path == self.robot_state_path.base_orientation_path:
+                menu.addAction(dont_use_as_base_orientation_str)
+            else:
+                menu.addAction(use_as_base_orientation_str)
+
+        # show the menu
+        action = menu.exec_(self.ui.variableTreeWidget.mapToGlobal(item_position))
+        if action is None:
+            return
+
+        item_path = self.get_item_path(item)
+
+        if action.text() == add_3d_point_str:
+            color = next(self.visualized_3d_points_colors_palette)
+
+            item.setForeground(0, QtGui.QBrush(QtGui.QColor(color.as_hex())))
+            self.meshcat_provider.register_3d_point(
+                item_key, list(color.as_normalized_rgb())
+            )
+            self.signal_provider.register_3d_point(item_key, item_path)
+            self.visualized_3d_points.add(item_key)
+
+        if action.text() == remove_3d_point_str:
+            self.meshcat_provider.unregister_3d_point(item_key)
+            self.signal_provider.unregister_3d_point(item_key)
+            self.visualized_3d_points.remove(item_key)
+            item.setForeground(0, QtGui.QBrush(QtGui.QColor(0, 0, 0)))
+
+        if (
+            action.text() == use_as_base_orientation_str
+            or action.text() == use_as_base_position_str
+        ):
+            item.setBackground(0, QtGui.QBrush(selected_base_color))
+
+        # check that the action is the one we want
+        if action.text() == use_as_base_position_str:
+            # if base position is already set we remove the color
+            if self.robot_state_path.base_position_path:
+                self.get_item_from_path(
+                    self.robot_state_path.base_position_path
+                ).setBackground(0, QtGui.QBrush(deselected_base_color))
+            self.robot_state_path.base_position_path = item_path
+
+        if action.text() == use_as_base_orientation_str:
+            # if base orientation is already set we remove the color
+            if self.robot_state_path.base_orientation_path:
+                self.get_item_from_path(
+                    self.robot_state_path.base_orientation_path
+                ).setBackground(0, QtGui.QBrush(deselected_base_color))
+            self.robot_state_path.base_orientation_path = item_path
+
+        if action.text() == dont_use_as_base_position_str:
+            self.robot_state_path.base_position_path = []
+            # if the item is used as base orientation we do not remove the color
+            if item_path != self.robot_state_path.base_orientation_path:
+                item.setBackground(0, QtGui.QBrush(deselected_base_color))
+
+        if action.text() == dont_use_as_base_orientation_str:
+            self.robot_state_path.base_orientation_path = []
+            # if the item is used as base position we do not remove the color
+            if item_path != self.robot_state_path.base_position_path:
+                item.setBackground(0, QtGui.QBrush(deselected_base_color))
+
+        # we update the robot state path
+        self.signal_provider.robot_state_path = self.robot_state_path
+
+    def get_item_from_path(self, path):
+        item = self.ui.variableTreeWidget.topLevelItem(0)
+        for subpath in path:
+            # find the item given its name
+            for child_id in range(item.childCount()):
+                if item.child(child_id).text(0) == subpath:
+                    item = item.child(child_id)
+                    break
+        return item
+
+    def get_item_path(self, item):
+        path = []
+        while item.parent() is not None:
+            path.append(item.text(0))
+            item = item.parent()
+        path.reverse()
+        return path
 
 
 class Logger:

--- a/robot_log_visualizer/ui/misc/visualizer.ui
+++ b/robot_log_visualizer/ui/misc/visualizer.ui
@@ -178,6 +178,9 @@
              <height>0</height>
             </size>
            </property>
+           <property name="contextMenuPolicy">
+            <enum>Qt::CustomContextMenu</enum>
+           </property>
            <property name="frameShape">
             <enum>QFrame::Box</enum>
            </property>

--- a/robot_log_visualizer/utils/utils.py
+++ b/robot_log_visualizer/utils/utils.py
@@ -9,3 +9,73 @@ class PeriodicThreadState(Enum):
     running = (0,)
     pause = (1,)
     closed = 2
+
+
+class RobotStatePath:
+    def __init__(self):
+        self.joints_state_path = []
+        self.base_orientation_path = []
+        self.base_position_path = []
+
+
+class Color:
+    """
+    Color class to handle color in different formats
+    """
+
+    def __init__(self, hex="#000000"):
+        self.hex = hex
+
+    def as_hex(self):
+        return self.hex
+
+    def as_rgb(self):
+        return self.hex_to_rgb(self.hex)
+
+    def as_normalized_rgb(self):
+        return self.get_to_normalized_rgb(self.hex)
+
+    @staticmethod
+    def hex_to_rgb(hex):
+        # https://stackoverflow.com/questions/29643352/converting-hex-to-rgb-value-in-python
+        hex = hex.lstrip("#")
+        hlen = len(hex)
+        return tuple(int(hex[i : i + hlen // 3], 16) for i in range(0, hlen, hlen // 3))
+
+    @staticmethod
+    def get_to_normalized_rgb(hex):
+        rgb = Color.hex_to_rgb(hex)
+        return (rgb[0] / 255.0, rgb[1] / 255.0, rgb[2] / 255.0)
+
+
+class ColorPalette:
+    """
+    Color palette class to handle color palette.
+    The user can get a color from the palette and the palette will automatically
+    cycle through the colors.
+    """
+
+    def __init__(self):
+        # use matlab color palette
+        self._color_palette = [
+            Color("#0072BD"),
+            Color("#D95319"),
+            Color("#EDB120"),
+            Color("#7E2F8E"),
+            Color("#77AC30"),
+            Color("#4DBEEE"),
+            Color("#A2142F"),
+            Color("#7E2F8E"),
+            Color("#77AC30"),
+            Color("#4DBEEE"),
+            Color("#A2142F"),
+        ]
+        self._index = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        color = self._color_palette[self._index]
+        self._index = (self._index + 1) % len(self._color_palette)
+        return color


### PR DESCRIPTION
This pull request introduces the option to set the base pose in the visualizer. Since we don't know a priori which signal will identify the base, the user can select the signal and, with a right-click, specify whether it should be used as the base position or orientation. For the base position, the signal must consist of three elements, while for base orientation, we accept a 3-element signal interpreted as roll-pitch-yaw (RPY) or a 4D vector interpreted as a quaternion (ijkw).

Additionally, the user can choose to visualize the 3D points in the visualizer by right-clicking on the signal and selecting 'Show as 3D points.' If the signal consists of 2 elements, the 3D point will be projected onto the ground.

The following video demonstrates how to use the application.


https://github.com/ami-iit/robot-log-visualizer/assets/16744101/60954a30-b79f-47d6-8f26-36329902d297


⚠️ This PR requires this commit of idyntree to work: https://github.com/robotology/idyntree/commit/6fb96d905ed75f0e298b13d6b47725fedc2dfa53

cc @S-Dafarra @DanielePucci @nicktrem @traversaro @carloscp3009 