### PR TITLE
Fix bug when loading specific mat files

### DIFF
--- a/robot_log_visualizer/file_reader/signal_provider.py
+++ b/robot_log_visualizer/file_reader/signal_provider.py
@@ -76,6 +76,8 @@ class SignalProvider(QThread):
                 continue
             if key == "#refs#":
                 continue
+            if key == "#subsystem#":
+                continue
             if "data" in value.keys():
                 data[key] = {}
                 level_ref = value["data"]["level"]
@@ -121,6 +123,8 @@ class SignalProvider(QThread):
             if not isinstance(value, h5py._hl.group.Group):
                 continue
             if key == "#refs#":
+                continue
+            if key == "#subsystem#":
                 continue
             if key == "log":
                 continue


### PR DESCRIPTION
This PR fixes a bug that occurs when loading mat files recorded with YarpLoggerDevice and then modified with a recent Matlab.

Before this fix, when loading such a mat file, the user gets:
![MicrosoftTeams-image (17)](https://github.com/user-attachments/assets/cfe1b6ed-7059-4067-a956-f0b05fb9f8e4)
